### PR TITLE
Authorize download formats

### DIFF
--- a/features/authorization.feature
+++ b/features/authorization.feature
@@ -9,7 +9,7 @@ Feature: Authorizing Access
     """
     class OnlyAuthorsAuthorization < ActiveAdmin::AuthorizationAdapter
 
-      def authorized?(action, subject = nil)
+      def authorized?(action, subject = nil, format = nil)
         case subject
 
         when normalized(Post)

--- a/features/index/formats.feature
+++ b/features/index/formats.feature
@@ -64,3 +64,53 @@ Feature: Index Formats
     And I should not see a link to download "XML"
     And I should not see a link to download "JSON"
     And I should not see a link to download "PDF"
+
+  Scenario: View index with an authorization adapter that forbids json
+    Given an index configuration of:
+    """
+      ActiveAdmin.register Post
+    """
+    And 1 post exists
+    And a configuration of:
+    """
+    class NoJSONAuthorization < ActiveAdmin::AuthorizationAdapter
+      def authorized?(action, subject = nil, format = nil)
+        case format
+        when :json
+          false
+        else
+          true
+        end
+      end
+    end
+
+    ActiveAdmin.application.authorization_adapter = OnlyAuthorsAuthorization
+    """
+    Then I should see a link to download "CSV"
+    And I should see a link to download "XML"
+    And I should not see a link to download "JSON"
+
+  Scenario: View index with an authorization adapter that forbids all formats
+    Given an index configuration of:
+    """
+      ActiveAdmin.register Post
+    """
+    And 1 post exists
+    And a configuration of:
+    """
+    class NoJSONAuthorization < ActiveAdmin::AuthorizationAdapter
+      def authorized?(action, subject = nil, format = nil)
+        case format
+        when :json, :xml, :csv
+          false
+        else
+          true
+        end
+      end
+    end
+
+    ActiveAdmin.application.authorization_adapter = OnlyAuthorsAuthorization
+    """
+    Then I should not see a link to download "CSV"
+    And I should not see a link to download "XML"
+    And I should not see a link to download "JSON"

--- a/lib/active_admin/authorization_adapter.rb
+++ b/lib/active_admin/authorization_adapter.rb
@@ -37,7 +37,7 @@ module ActiveAdmin
     end
 
     # Returns true of false depending on if the user is authorized to perform
-    # the action on the subject.
+    # the action on the subject with the given format.
     #
     # @param [Symbol] action The name of the action to perform. Usually this will be
     #        one of the `ActiveAdmin::Auth::*` symbols.
@@ -49,8 +49,10 @@ module ActiveAdmin
     #        global navigation. To deal with this nicely in a case statement, take
     #        a look at `#normalized(klasss)`
     #
+    # @param [Symbol] format The format that the user is trying to request.
+    #
     # @return [Boolean]
-    def authorized?(action, subject = nil)
+    def authorized?(action, subject = nil, format = nil)
       true
     end
 

--- a/lib/active_admin/base_controller/authorization.rb
+++ b/lib/active_admin/base_controller/authorization.rb
@@ -32,10 +32,12 @@ module ActiveAdmin
       # @param [any] subject The subject that the user is trying to perform
       #                 the action on.
       #
+      # @param [Symbol] format The format that the user is trying to request.
+      #
       # @return [Boolean]
       #
-      def authorized?(action, subject = nil)
-        active_admin_authorization.authorized?(action, subject)
+      def authorized?(action, subject = nil, format = nil)
+        active_admin_authorization.authorized?(action, subject, format)
       end
 
 
@@ -49,13 +51,16 @@ module ActiveAdmin
       # @param [any] subject The subject that the user is trying to perform
       #                 the action on.
       #
+      # @param [Symbol] format The format that the user is trying to request.
+      #
       # @return [Boolean] True if authorized, otherwise raises
       #                 an ActiveAdmin::AccessDenied.
-      def authorize!(action, subject = nil)
-        unless authorized? action, subject
+      def authorize!(action, subject = nil, format = nil)
+        unless authorized? action, subject, format
           raise ActiveAdmin::AccessDenied.new(current_active_admin_user,
                                               action,
-                                              subject)
+                                              subject,
+                                              format)
         end
       end
 

--- a/lib/active_admin/cancan_adapter.rb
+++ b/lib/active_admin/cancan_adapter.rb
@@ -11,8 +11,8 @@ module ActiveAdmin
 
   class CanCanAdapter < AuthorizationAdapter
 
-    def authorized?(action, subject = nil)
-      cancan_ability.can?(action, subject)
+    def authorized?(action, subject = nil, format = nil)
+      cancan_ability.can?(action, subject, format)
     end
 
     def cancan_ability

--- a/lib/active_admin/error.rb
+++ b/lib/active_admin/error.rb
@@ -5,8 +5,8 @@ module ActiveAdmin
   class AccessDenied < StandardError
     attr_reader :user, :action, :subject
 
-    def initialize(user, action, subject)
-      @user, @action, @subject = user, action, subject
+    def initialize(user, action, subject, format)
+      @user, @action, @subject, @format = user, action, subject, format
 
       super()
     end

--- a/lib/active_admin/pundit_adapter.rb
+++ b/lib/active_admin/pundit_adapter.rb
@@ -9,9 +9,9 @@ module ActiveAdmin
 
   class PunditAdapter < AuthorizationAdapter
 
-    def authorized?(action, subject = nil)
+    def authorized?(action, subject = nil, format = nil)
       policy = retrieve_policy(subject)
-      action = format_action(action, subject)
+      action = format_action(action, subject, format)
 
       policy.respond_to?(action) && policy.public_send(action)
     end
@@ -42,13 +42,18 @@ module ActiveAdmin
       end
     end
 
-    def format_action(action, subject)
+    def format_action(action, subject, format = nil)
       # https://github.com/elabs/pundit/blob/master/lib/generators/pundit/install/templates/application_policy.rb
       case action
       when Auth::CREATE  then :create?
       when Auth::UPDATE  then :update?
-      when Auth::READ    then subject.is_a?(Class) ? :index? : :show?
       when Auth::DESTROY then subject.is_a?(Class) ? :destroy_all? : :destroy?
+      when Auth::READ
+        if subject.is_a?(Class)
+          format.nil? || format == :html ? :index? : "download_#{format}?".to_sym
+        else
+          :show?
+        end
       else "#{action}?"
       end
     end

--- a/lib/active_admin/resource_controller/data_access.rb
+++ b/lib/active_admin/resource_controller/data_access.rb
@@ -40,7 +40,7 @@ module ActiveAdmin
       def collection
         get_collection_ivar || begin
           collection = find_collection
-          authorize! Authorization::READ, active_admin_config.resource_class
+          authorize! Authorization::READ, active_admin_config.resource_class, params[:format].try(:to_sym)
           set_collection_ivar collection
         end
       end

--- a/lib/active_admin/view_helpers/download_format_links_helper.rb
+++ b/lib/active_admin/view_helpers/download_format_links_helper.rb
@@ -4,6 +4,9 @@ module ActiveAdmin
 
       def build_download_format_links(formats = self.class.formats)
         params = request.query_parameters.except :format, :commit
+        formats = formats.select { |format| authorized?(:index, resource_class, format) }
+        return if formats.empty?
+
         div class: "download_links" do
           span I18n.t('active_admin.download')
           formats.each do |format|


### PR DESCRIPTION
Intended use of authorization model:

``` ruby
# config/initializers/active_admin.rb
config.authorization_adapter = "CustomAuthorization"

# app/models/custom_authorization.rb
class CustomAuthorization < ActiveAdmin::AuthorizationAdapter

  def authorized?(action, subject = nil, format = nil)
    case subject
    when normalized(Post)
      # Only let the author export as XML
      if format == :xml
        subject.author == user
      else
        true
      end
    else
      true
    end
  end

end

```

or

``` ruby
# config/initializers/active_admin.rb
config.authorization_adapter = "NoXMLAuthorization"

# app/models/no_xml_authorization.rb
class NoXMLAuthorization < ActiveAdmin::AuthorizationAdapter

  def authorized?(action, subject = nil, format = nil)
    case format
    when :xml
      false
    else
      true
    end
  end

end

```
